### PR TITLE
Add job crawling endpoint to enhance job posting extraction capabilities

### DIFF
--- a/app/agents/jobs_crawl_agent.py
+++ b/app/agents/jobs_crawl_agent.py
@@ -1,0 +1,151 @@
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.models.anthropic import AnthropicModel
+from dataclasses import dataclass
+from typing import List, Dict, Any, Optional
+from app.agents.utils.firecrawl import app as firecrawl_app
+import os
+from dotenv import load_dotenv
+from pydantic import BaseModel
+
+# Load environment variables from .env file
+load_dotenv()
+
+
+class JobPostingInfo(BaseModel):
+    title: str
+    company: Optional[str] = None
+    description: str
+    url: str
+    location: Optional[str] = None
+    salary_range: Optional[str] = None
+    date_posted: Optional[str] = None
+
+
+@dataclass
+class JobsCrawlDeps:
+    website_url: str
+
+
+# Get Anthropic API key from environment variables
+anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
+if not anthropic_api_key:
+    raise ValueError("ANTHROPIC_API_KEY not found in environment variables")
+
+model = AnthropicModel("claude-3-5-sonnet-latest", api_key=anthropic_api_key)
+
+# Define the agent with proper deps_type and result_type
+jobs_crawl_agent = Agent(
+    model,
+    deps_type=JobsCrawlDeps,
+    result_type=List[JobPostingInfo],
+    system_prompt="You are a helpful assistant that can extract job postings from job websites.",
+)
+
+
+@jobs_crawl_agent.tool
+def crawl_job_website(
+    ctx: RunContext[JobsCrawlDeps],
+) -> List[JobPostingInfo]:
+    """
+    Tool that crawls a job posting website and extracts job information.
+
+    Args:
+        ctx: The run context containing the dependencies (website_url)
+
+    Returns:
+        A list of JobPostingInfo objects
+    """
+    website_url = ctx.deps.website_url
+    job_postings = []
+
+    print(f"Crawling website: {website_url}")
+
+    try:
+        # Use Firecrawl to fetch website content
+        crawl_result = firecrawl_app.crawl(
+            url=website_url,
+            params={
+                "wait_for": "networkidle0",  # Wait until network is idle
+                "timeout": 30000,  # 30 seconds timeout
+            },
+        )
+
+        # Extract content from the crawl result
+        content = ""
+        if isinstance(crawl_result, dict):
+            if "content" in crawl_result:
+                content = crawl_result["content"]
+            elif "html" in crawl_result:
+                content = crawl_result["html"]
+            elif "text" in crawl_result:
+                content = crawl_result["text"]
+            elif "markdown" in crawl_result:
+                content = crawl_result["markdown"]
+
+        if not content:
+            print(f"No content found in crawl result for {website_url}")
+            return []
+
+        # Use Claude to parse job postings from content
+        parse_result = model.generate(
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You are an AI expert at extracting job postings from websites. Your task is to extract job posting information from the provided website content.",
+                },
+                {
+                    "role": "user",
+                    "content": f"""
+                    I need you to extract job postings from this job website content. 
+                    
+                    Please identify each distinct job posting and extract the following information:
+                    - Job title
+                    - Company name (if available)
+                    - Job description (a brief summary)
+                    - Location (if available)
+                    - Salary information (if available)
+                    - Date posted (if available)
+                    
+                    For each job posting, provide the information in a structured JSON format.
+                    
+                    Here's the website content:
+                    ```
+                    {content[:50000]}  # Limit content to avoid token limits
+                    ```
+                    
+                    Format your response as a JSON array of job postings. Each job posting should include title, company, description, location, salary_range, and date_posted fields.
+                    """,
+                },
+            ],
+            max_tokens=4000,
+            temperature=0,
+            response_format={"type": "json_object"},
+        )
+
+        # Extract and process job postings from the model's response
+        if parse_result and hasattr(parse_result, "content"):
+            try:
+                import json
+                parsed_data = json.loads(parse_result.content)
+                
+                if "job_postings" in parsed_data and isinstance(parsed_data["job_postings"], list):
+                    for job_data in parsed_data["job_postings"]:
+                        # Create JobPostingInfo objects from the extracted data
+                        job_postings.append(
+                            JobPostingInfo(
+                                title=job_data.get("title", "Unknown Title"),
+                                company=job_data.get("company"),
+                                description=job_data.get("description", "No description available"),
+                                url=website_url,  # Use the main website URL since we don't have specific URLs
+                                location=job_data.get("location"),
+                                salary_range=job_data.get("salary_range"),
+                                date_posted=job_data.get("date_posted"),
+                            )
+                        )
+            except Exception as e:
+                print(f"Error parsing job postings from model response: {str(e)}")
+
+    except Exception as e:
+        print(f"Error crawling website {website_url}: {str(e)}")
+
+    return job_postings

--- a/app/api/v1/routes/job_routes.py
+++ b/app/api/v1/routes/job_routes.py
@@ -3,8 +3,15 @@ from app.schemas.websites_search_schemas import (
     SearchJobPostingWebsitesRequest,
     SearchJobPostingWebsitesResponse,
 )
+from app.schemas.jobs_crawl_schemas import (
+    JobCrawlRequest,
+    JobCrawlResponse,
+)
 from app.services.job_posting_websites_search_service import (
     search_job_posting_websites_service,
+)
+from app.services.jobs_crawl_service import (
+    jobs_crawl_service,
 )
 
 router = APIRouter(tags=["jobs"])
@@ -38,3 +45,37 @@ async def search_job_posting_websites(
     is pending. Future versions will connect to a full browsing-capable AI agent.
     """
     return await search_job_posting_websites_service(request)
+
+
+@router.post(
+    "/crawl-job-website",
+    response_model=JobCrawlResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Crawl job postings from a website",
+    response_description="A list of job postings extracted from the provided website",
+)
+async def crawl_job_website(
+    request: JobCrawlRequest,
+):
+    """
+    Crawl and extract job postings from a specified job posting website.
+    
+    This endpoint accepts a job posting website URL and uses an AI agent to crawl
+    the website and extract detailed information about each job posting found.
+    
+    Parameters:
+    - **website_url**: Required URL of the job posting website to crawl
+      (e.g., "https://www.linkedin.com/jobs/search?keywords=software+engineer")
+    
+    Returns:
+    - List of job postings found on the website, including details like:
+      - Job title
+      - Company name (if available)
+      - Job description
+      - Location (if available)
+      - Salary range (if available)
+      - Date posted (if available)
+    - Total count of job postings found
+    - The website URL that was crawled
+    """
+    return await jobs_crawl_service(request)

--- a/app/schemas/jobs_crawl_schemas.py
+++ b/app/schemas/jobs_crawl_schemas.py
@@ -1,0 +1,130 @@
+from pydantic import BaseModel, Field, field_validator
+from typing import Optional, List
+import re
+
+
+class JobCrawlRequest(BaseModel):
+    website_url: str = Field(
+        ...,
+        description="URL of the job posting website to crawl",
+        min_length=1,
+        max_length=500,
+        examples=["https://www.linkedin.com/jobs/search?keywords=software+engineer"],
+    )
+
+    @field_validator("website_url")
+    def validate_website_url(cls, v):
+        if not v.strip():
+            raise ValueError("website_url cannot be empty")
+        
+        # Simple URL validation
+        url_pattern = re.compile(
+            r'^(https?://)?(www\.)?'  # http:// or https:// + www. (optional)
+            r'[a-zA-Z0-9][\w\-\.]+\.[a-zA-Z]{2,}'  # domain
+            r'(/[a-zA-Z0-9\-\._~:/?#[\]@!$&\'\(\)*+,;=]*)?$'  # path, query, etc.
+        )
+        
+        if not url_pattern.match(v):
+            raise ValueError("Invalid URL format")
+        
+        # Ensure URL has http:// or https:// prefix
+        if not v.startswith(('http://', 'https://')):
+            v = f"https://{v}"
+            
+        return v
+
+    class Config:
+        schema_extra = {
+            "example": {"website_url": "https://www.linkedin.com/jobs/search?keywords=software+engineer"}
+        }
+
+
+class JobPosting(BaseModel):
+    title: str = Field(
+        ...,
+        description="Job title",
+        examples=["Senior Software Engineer", "Data Scientist", "Product Manager"],
+    )
+    company: Optional[str] = Field(
+        None,
+        description="Company name",
+        examples=["Google", "Microsoft", "Amazon"],
+    )
+    description: str = Field(
+        ...,
+        description="Job description",
+        examples=["We are looking for a senior software engineer with 5+ years of experience..."],
+    )
+    url: str = Field(
+        ...,
+        description="Job posting URL",
+        examples=["https://www.linkedin.com/jobs/view/12345678"],
+    )
+    location: Optional[str] = Field(
+        None,
+        description="Job location",
+        examples=["San Francisco, CA", "Remote", "New York, NY"],
+    )
+    salary_range: Optional[str] = Field(
+        None,
+        description="Salary range",
+        examples=["$100,000 - $150,000", "$80k - $120k per year"],
+    )
+    date_posted: Optional[str] = Field(
+        None,
+        description="Date when the job was posted",
+        examples=["2023-01-15", "3 days ago", "Yesterday"],
+    )
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "title": "Senior Software Engineer",
+                "company": "Google",
+                "description": "We are looking for a senior software engineer with 5+ years of experience...",
+                "url": "https://www.linkedin.com/jobs/view/12345678",
+                "location": "San Francisco, CA",
+                "salary_range": "$150,000 - $200,000",
+                "date_posted": "2023-01-15",
+            }
+        }
+
+
+class JobCrawlResponse(BaseModel):
+    results: List[JobPosting] = Field(
+        ..., description="List of job postings found"
+    )
+    total_found: int = Field(
+        ..., description="Total number of job postings found", ge=0
+    )
+    website_url: str = Field(
+        ..., description="URL of the website that was crawled"
+    )
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "results": [
+                    {
+                        "title": "Senior Software Engineer",
+                        "company": "Google",
+                        "description": "We are looking for a senior software engineer with 5+ years of experience...",
+                        "url": "https://www.linkedin.com/jobs/view/12345678",
+                        "location": "San Francisco, CA",
+                        "salary_range": "$150,000 - $200,000",
+                        "date_posted": "2023-01-15",
+                    },
+                    {
+                        "title": "Full Stack Developer",
+                        "company": "Microsoft",
+                        "description": "Join our team to build cutting-edge web applications...",
+                        "url": "https://www.linkedin.com/jobs/view/87654321",
+                        "location": "Remote",
+                        "salary_range": "$120,000 - $180,000",
+                        "date_posted": "2023-01-10",
+                    }
+                ],
+                "total_found": 2,
+                "website_url": "https://www.linkedin.com/jobs/search?keywords=software+engineer",
+            }
+        }

--- a/app/scripts/test_crawl_agent.py
+++ b/app/scripts/test_crawl_agent.py
@@ -1,0 +1,49 @@
+import asyncio
+import sys
+import os
+
+# Add the parent directory to the Python path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from app.agents.jobs_crawl_agent import jobs_crawl_agent, JobsCrawlDeps
+
+
+async def test_jobs_crawl_agent():
+    """
+    Test function for the jobs_crawl_agent.
+    This function runs the agent with a test URL and prints the results.
+    """
+    print("Testing jobs_crawl_agent...")
+    
+    # Test URL - LinkedIn jobs page for software engineers
+    test_url = "https://www.linkedin.com/jobs/search?keywords=software%20engineer"
+    
+    # Create agent dependencies
+    deps = JobsCrawlDeps(website_url=test_url)
+    
+    try:
+        # Run the agent
+        print(f"Crawling: {test_url}")
+        result = await jobs_crawl_agent.run(
+            "Extract job postings from this website", deps=deps
+        )
+        
+        # Print results
+        print(f"\nFound {len(result.data)} job postings:")
+        for i, job in enumerate(result.data, 1):
+            print(f"\nJob {i}:")
+            print(f"Title: {job.title}")
+            print(f"Company: {job.company or 'N/A'}")
+            print(f"Location: {job.location or 'N/A'}")
+            print(f"Salary: {job.salary_range or 'N/A'}")
+            print(f"Date Posted: {job.date_posted or 'N/A'}")
+            print(f"Description: {job.description[:100]}...")
+            
+        print("\nTest completed successfully!")
+        
+    except Exception as e:
+        print(f"Error testing jobs_crawl_agent: {str(e)}")
+
+
+if __name__ == "__main__":
+    asyncio.run(test_jobs_crawl_agent())

--- a/app/services/jobs_crawl_service.py
+++ b/app/services/jobs_crawl_service.py
@@ -1,0 +1,87 @@
+import logging
+from fastapi import HTTPException
+from app.schemas.jobs_crawl_schemas import (
+    JobCrawlRequest,
+    JobCrawlResponse,
+    JobPosting
+)
+from app.agents.jobs_crawl_agent import (
+    jobs_crawl_agent,
+    JobsCrawlDeps,
+    JobPostingInfo
+)
+
+# Set up logger
+logger = logging.getLogger(__name__)
+
+
+async def jobs_crawl_service(
+    request: JobCrawlRequest,
+) -> JobCrawlResponse:
+    """
+    Service that handles crawling job postings from a specified website.
+
+    Args:
+        request: The JobCrawlRequest containing the website URL to crawl
+
+    Returns:
+        JobCrawlResponse containing the crawled job postings
+
+    Raises:
+        HTTPException: If an error occurs during the crawling process
+    """
+    try:
+        logger.info(f"Processing job crawl request for website: {request.website_url}")
+
+        # Create dependencies for the agent
+        deps = JobsCrawlDeps(
+            website_url=request.website_url
+        )
+
+        # Run the agent
+        logger.info(f"Starting agent to crawl website: {request.website_url}")
+        agent_result = await jobs_crawl_agent.run(
+            "Crawl the provided job website and extract job postings", deps=deps
+        )
+
+        # Log the result
+        logger.info(f"Agent result type: {type(agent_result)}")
+        logger.info(f"Agent found {len(agent_result.data)} job postings")
+
+        # Convert JobPostingInfo objects to JobPosting schema objects
+        job_postings = []
+        for job_info in agent_result.data:
+            job_postings.append(
+                JobPosting(
+                    title=job_info.title,
+                    company=job_info.company,
+                    description=job_info.description,
+                    url=job_info.url,
+                    location=job_info.location,
+                    salary_range=job_info.salary_range,
+                    date_posted=job_info.date_posted
+                )
+            )
+
+        # Create response
+        response = JobCrawlResponse(
+            results=job_postings,
+            total_found=len(job_postings),
+            website_url=request.website_url
+        )
+
+        logger.info(f"Completed job crawl with {response.total_found} results from {request.website_url}")
+        return response
+
+    except ValueError as e:
+        # Handle validation errors
+        logger.error(f"Validation error in job crawl: {str(e)}")
+        raise HTTPException(status_code=400, detail=str(e))
+    except ConnectionError as e:
+        # Handle connection errors
+        logger.error(f"Connection error in job crawl: {str(e)}")
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable")
+    except Exception as e:
+        # Handle unexpected errors
+        logger.exception(f"Unexpected error in job crawl: {str(e)}")
+        raise HTTPException(status_code=500, detail="An unexpected error occurred")


### PR DESCRIPTION
- Introduced a new endpoint `/crawl-job-website` for crawling job postings from specified websites.
- Added request and response schemas for job crawling functionality.
- Implemented service integration for job crawling to extract detailed job posting information.
- Updated documentation to reflect the new endpoint and its parameters.